### PR TITLE
Use technical version for docSearch

### DIFF
--- a/src/partials/docsearch-head-metadata.hbs
+++ b/src/partials/docsearch-head-metadata.hbs
@@ -1,1 +1,1 @@
-    <meta name="docsearch:version" content="{{page.componentVersion.displayVersion}}" />
+    <meta name="docsearch:version" content="{{page.componentVersion.version}}" />


### PR DESCRIPTION
Don't use display version, which can be customized to be more user friendly.

This doesn't make any change for existing docs which don't specify display version. But the new LATEST version will specify the version as "master" to remove version from the URL and will specify LATEST as the display version. The value "master" will be used in the search field to specify the version for Antora, so Antora needs to index the docs also with the value "master" and not "LATEST". 