### PR TITLE
Removed unneeded character from meta tag.

### DIFF
--- a/src/js/vendor/docSearch.bundle.js
+++ b/src/js/vendor/docSearch.bundle.js
@@ -2,7 +2,7 @@ var docsearch = require('@docsearch/js')
 
 function getCurrentVersion () {
   var docsVersion = null
-  var versionMetaTag = document.querySelector('cmeta[name="docsearch:version"]')
+  var versionMetaTag = document.querySelector('meta[name="docsearch:version"]')
   if (versionMetaTag) {
     docsVersion = versionMetaTag.content
   }


### PR DESCRIPTION
This should fix the Cloud search not returning any results.